### PR TITLE
Disable the no-descending-specificity rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,12 +98,7 @@ module.exports = {
         "at-rule-semicolon-space-before": "never",
         "indentation": 4,
         "max-line-length": 120,
-        "no-descending-specificity": [
-            true,
-            {
-                "severity": "warning"
-            }
-        ],
+        "no-descending-specificity": null,
         "no-duplicate-selectors": true,
         "no-empty-source": true,
         "block-no-empty": true,


### PR DESCRIPTION
The `no-descending-specificity` in my opinion make not much sence as it will throw warnings in cases like:

```scss
ul {
    ol {
        // ..
    }
}

ol {
    ul {
        // ..
    }
}
```

or where it make sense to have a specific selector before another for readability:

```scss
.form__input,
.form__select,
.form__textarea {
    // ..

    &:invalid {
        border-color: red;
        box-shadow: none;
    }
}

// ...

.form__textarea {
     height: 100px
}
```

As in the cases where I did see the warning it did make sense to have it in that order I would skip that rule. Its also not a recommended rule by stylelint.