### PR TITLE
Add font-weight-notation rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ module.exports = {
                 "ignoreAtRules": [ "if", "else", "elseif" ]
             }
         ],
+        "font-weight-notation": "named-where-possible",
         "string-quotes": "single",
         "value-keyword-case": "lower",
         "declaration-empty-line-before": "never",

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = {
                 "ignoreAtRules": [ "if", "else", "elseif" ]
             }
         ],
-        "font-weight-notation": "named-where-possible",
+        "font-weight-notation": "numeric",
         "string-quotes": "single",
         "value-keyword-case": "lower",
         "declaration-empty-line-before": "never",


### PR DESCRIPTION
The font-weight should be normalized using [font-weight-notation rule](https://stylelint.io/user-guide/rules/font-weight-notation/)

There are 2 options: 
 - numeric
 - named-where-possible

This avoids having 400/normal and 700/bold mixed in a project. I personally prefer **named-where-possible** as it is more self explanatory but for me its ok to have also always **numeric** values.