### PR TITLE
Allow container queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
                     "extend",
                     "include",
                     "mixin",
+                    "container",
                     "if",
                     "for",
                     "forward",

--- a/test/container-query.scss
+++ b/test/container-query.scss
@@ -1,0 +1,11 @@
+// polyfill available here: https://github.com/jsxtools/cqfill
+
+.container {
+    contain: layout inline-size;
+}
+
+@container (min-width: 700px) {
+    .contained {
+        /* styles applied when a container is at least 700px */
+    }
+}


### PR DESCRIPTION
[Container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries) are now available behind a flag and can be polyfilled with browsers supporting [css variables](https://caniuse.com/css-variables) (no IE or legacy Edge support) using [cqfill](https://github.com/jsxtools/cqfill).

Example: https://codepen.io/jonneal/full/rNjRBOX

Current state: https://caniuse.com/css-container-queries as currently all is red and so this is still under discussion and at current state not ready for production usage but think the stylelint should not disallow, so it can be if ready be used as soon as possible.