### PR TITLE
Allow the usage of currentColor

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,12 @@ module.exports = {
         ],
         "font-weight-notation": "numeric",
         "string-quotes": "single",
-        "value-keyword-case": "lower",
+        "value-keyword-case": [
+            "lower",
+            {
+                camelCaseSvgKeywords: true,
+            }
+        ],
         "declaration-empty-line-before": "never",
         "selector-attribute-quotes": "always",
         "selector-class-pattern": "^[a-z][a-z-A-Z_0-9]*$",

--- a/test/current-color.scss
+++ b/test/current-color.scss
@@ -1,0 +1,3 @@
+.test {
+    color: currentColor;
+}


### PR DESCRIPTION
Currently `currentColor` is converted to `currentcolor` but should stay as `currentColor` for readability.

https://stylelint.io/user-guide/rules/value-keyword-case/#camelcasesvgkeywords-true--false-default-false