### PR TITLE
Refactored rules and extend from "stylelint-config-standard-scss"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,90 +1,94 @@
-"use strict"
+'use strict';
 
 module.exports = {
-    "extends": "stylelint-config-standard-scss",
-    "rules": {
-        "at-rule-empty-line-before": [
-            "always",
+    'extends': 'stylelint-config-standard-scss',
+    'customSyntax': 'scss',
+    'rules': {
+        'at-rule-empty-line-before': [
+            'always',
             {
-                "ignoreAtRules": [
-                    "if",
-                    "media",
-                    "return",
-                    "extend",
-                    "include",
-                    "else",
+                except: ['blockless-after-blockless', 'first-nested'],
+                ignore: ['after-comment'],
+                ignoreAtRules: [
+                    'if',
+                    'media',
+                    'return',
+                    'extend',
+                    'include',
+                    'else',
                 ]
             }
         ],
-        "font-weight-notation": "numeric",
-        "value-keyword-case": [
-            "lower",
+        'font-weight-notation': 'numeric',
+        'value-keyword-case': [
+            'lower',
             {
                 camelCaseSvgKeywords: true,
             }
         ],
-        "keyframes-name-pattern": [
-            "^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$",
+        'keyframes-name-pattern': [
+            '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
             {
-                message: (name) => `Expected keyframe name "${name}" to be camelCase`,
+                message: (name) => `Expected keyframe name '${name}' to be camelCase`,
             },
         ],
-        "selector-class-pattern": [
-            "^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?(--[a-z0-9]([-]?[a-z0-9]+)*)?$",
+        'selector-class-pattern': [
+            '^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?(--[a-z0-9]([-]?[a-z0-9]+)*)?$',
             {
                 resolveNestedSelectors: true,
-                message: (selector) => `Expected class selector "${selector}" to match BEM CSS pattern https://en.bem.info/methodology/css. Selector validation tool: https://regexr.com/3apms`,
+                message: (selector) => `Expected class selector '${selector}' to match BEM CSS pattern (https://en.bem.info/methodology/css). Selector validation tool: https://regexr.com/3apms`,
             },
         ],
-        "selector-max-compound-selectors": [
+        'selector-max-compound-selectors': [
             3,
             {
-                "severity": "warning"
+                severity: 'warning'
             }
         ],
-        "selector-max-id": 0,
-        "selector-max-type": [
+        'selector-max-id': 0,
+        'selector-max-type': [
             2,
             {
-                "severity": "warning"
+                severity: 'warning'
             }
         ],
-        "selector-max-combinators": [
+        'selector-max-combinators': [
             2,
             {
-                "severity": "warning"
+                severity: 'warning'
             }
         ],
-        "selector-max-universal": 1,
-        "selector-max-specificity": "0,3,1",
-        "custom-media-pattern": [
-            "^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$",
+        'selector-max-universal': 1,
+        'selector-max-specificity': '0,3,1',
+        'custom-media-pattern': [
+            '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
             {
-                message: (name) => `Expected custom media query name "${name}" to be camelCase`,
+                message: (name) => `Expected custom media query name '${name}' to be camelCase`,
             },
         ],
-        "no-duplicate-selectors": true,
-        "no-empty-source": true,
-        "block-no-empty": true,
-        "color-hex-length": "long",
-        "number-max-precision": 3,
-        "scss/dollar-variable-pattern": [
-            "^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$",
+        'no-duplicate-selectors': true,
+        'no-empty-source': true,
+        'block-no-empty': true,
+        'color-hex-length': 'long',
+        'comment-no-empty': true,
+        'number-max-precision': 3,
+        'scss/dollar-variable-pattern': [
+            '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
             {
-                message: "Expected variable to be camelCase",
+                message: 'Expected variable to be camelCase',
             },
         ],
-        "scss/percent-placeholder-pattern": [
-            "^[a-z][a-z-A-Z0-9]*$",
+        'scss/percent-placeholder-pattern': [
+            '^[a-z][a-z-A-Z0-9]*$',
             {
-                message: "Expected placeholder to be camelCase",
+                message: 'Expected placeholder to be camelCase',
             },
         ],
-        "scss/declaration-nested-properties": "never",
-        "scss/at-function-pattern": [
-            "^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$",
+        'scss/declaration-nested-properties': 'never',
+        'scss/at-function-pattern': [
+            '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
             {
-                message: "Expected function name to be camelCase",
+                message: 'Expected function name to be camelCase',
             },
         ],
     }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     'extends': 'stylelint-config-standard-scss',
-    'customSyntax': 'scss',
+    'customSyntax': 'postcss-scss',
     'rules': {
         'at-rule-empty-line-before': [
             'always',
@@ -19,19 +19,20 @@ module.exports = {
                 ]
             }
         ],
+        'block-no-empty': true,
+        'color-hex-length': 'long',
+        'comment-no-empty': true,
+        'declaration-empty-line-before': 'never',
         'font-weight-notation': 'numeric',
-        'value-keyword-case': [
-            'lower',
-            {
-                camelCaseSvgKeywords: true,
-            }
-        ],
         'keyframes-name-pattern': [
             '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
             {
                 message: (name) => `Expected keyframe name '${name}' to be camelCase`,
             },
         ],
+        'no-descending-specificity': null,
+        'no-duplicate-selectors': true,
+        'no-empty-source': true,
         'selector-class-pattern': [
             '^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?(--[a-z0-9]([-]?[a-z0-9]+)*)?$',
             {
@@ -60,35 +61,38 @@ module.exports = {
         ],
         'selector-max-universal': 1,
         'selector-max-specificity': '0,3,1',
-        'custom-media-pattern': [
+        'selector-not-notation': 'simple',
+        'value-keyword-case': [
+            'lower',
+            {
+                camelCaseSvgKeywords: true,
+            }
+        ],
+        'scss/at-function-pattern': [
             '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
             {
-                message: (name) => `Expected custom media query name '${name}' to be camelCase`,
+                message: 'Expected function name to be camelCase',
             },
         ],
-        'no-duplicate-selectors': true,
-        'no-empty-source': true,
-        'block-no-empty': true,
-        'color-hex-length': 'long',
-        'comment-no-empty': true,
-        'number-max-precision': 3,
+        'scss/at-mixin-argumentless-call-parentheses': 'always',
+        'scss/at-mixin-pattern': [
+            '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
+            {
+                message: 'Expected mixin to be camelCase',
+            },
+        ],
+        'scss/declaration-nested-properties': 'never',
         'scss/dollar-variable-pattern': [
             '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
             {
                 message: 'Expected variable to be camelCase',
             },
         ],
+        'scss/no-global-function-names': null,
         'scss/percent-placeholder-pattern': [
             '^[a-z][a-z-A-Z0-9]*$',
             {
                 message: 'Expected placeholder to be camelCase',
-            },
-        ],
-        'scss/declaration-nested-properties': 'never',
-        'scss/at-function-pattern': [
-            '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
-            {
-                message: 'Expected function name to be camelCase',
             },
         ],
     }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = {
                 except: ['blockless-after-blockless', 'first-nested'],
                 ignore: ['after-comment'],
                 ignoreAtRules: [
-                    'if',
                     'media',
                     'return',
                     'extend',

--- a/index.js
+++ b/index.js
@@ -1,85 +1,41 @@
 "use strict"
 
 module.exports = {
-    "extends": "stylelint-config-standard",
-    "customSyntax": "scss",
-    "plugins": [
-        "stylelint-scss"
-    ],
-    "ignoreFiles": [
-        "sass/vendor/*.scss"
-    ],
+    "extends": "stylelint-config-standard-scss",
     "rules": {
         "at-rule-empty-line-before": [
             "always",
             {
-                "except": [
-                    "blockless-after-same-name-blockless",
-                    "first-nested"
-                ],
-                "ignore": [
-                    "after-comment"
-                ],
                 "ignoreAtRules": [
-                    "extend",
-                    "include",
-                    "else",
-                    "elseif",
-                    "content"
-                ]
-            }
-        ],
-        "at-rule-no-unknown": [
-            true,
-            {
-                "ignoreAtRules": [
-                    "content",
-                    "extend",
-                    "include",
-                    "mixin",
-                    "container",
                     "if",
-                    "for",
-                    "forward",
-                    "else",
-                    "elseif",
-                    "error",
-                    "each",
-                    "function",
+                    "media",
                     "return",
-                    "use",
-                    "while"
+                    "extend",
+                    "include",
+                    "else",
                 ]
-            }
-        ],
-        "at-rule-name-space-after": "always",
-        "function-comma-newline-before": "never-multi-line",
-        "function-name-case": [
-            "lower",
-            {
-                "ignoreFunctions": [
-                    "/^[a-z][a-z-A-Z0-9]*$/"
-                ]
-            }
-        ],
-        "function-no-unknown": null, // https://github.com/stylelint-scss/stylelint-scss/issues/589
-        "block-closing-brace-newline-after": [
-            "always",
-            {
-                "ignoreAtRules": [ "if", "else", "elseif" ]
             }
         ],
         "font-weight-notation": "numeric",
-        "string-quotes": "single",
         "value-keyword-case": [
             "lower",
             {
                 camelCaseSvgKeywords: true,
             }
         ],
-        "declaration-empty-line-before": "never",
-        "selector-attribute-quotes": "always",
-        "selector-class-pattern": "^[a-z][a-z-A-Z_0-9]*$",
+        "keyframes-name-pattern": [
+            "^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$",
+            {
+                message: (name) => `Expected keyframe name "${name}" to be camelCase`,
+            },
+        ],
+        "selector-class-pattern": [
+            "^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?(--[a-z0-9]([-]?[a-z0-9]+)*)?$",
+            {
+                resolveNestedSelectors: true,
+                message: (selector) => `Expected class selector "${selector}" to match BEM CSS pattern https://en.bem.info/methodology/css. Selector validation tool: https://regexr.com/3apms`,
+            },
+        ],
         "selector-max-compound-selectors": [
             3,
             {
@@ -100,60 +56,36 @@ module.exports = {
             }
         ],
         "selector-max-universal": 1,
-        "selector-max-specificity": "0,3,0",
-        "selector-list-comma-newline-before": "never-multi-line",
-        "selector-list-comma-space-after": "always-single-line",
-        "custom-media-pattern": "^[a-z][a-z-A-Z0-9]*$",
-        "media-feature-parentheses-space-inside": "never",
-        "media-query-list-comma-newline-before": "never-multi-line",
-        "at-rule-semicolon-space-before": "never",
-        "indentation": 4,
-        "max-line-length": 120,
-        "no-descending-specificity": null,
+        "selector-max-specificity": "0,3,1",
+        "custom-media-pattern": [
+            "^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$",
+            {
+                message: (name) => `Expected custom media query name "${name}" to be camelCase`,
+            },
+        ],
         "no-duplicate-selectors": true,
         "no-empty-source": true,
         "block-no-empty": true,
         "color-hex-length": "long",
-        "color-hex-case": ["upper"],
-        "rule-empty-line-before": [
-            "always",
+        "number-max-precision": 3,
+        "scss/dollar-variable-pattern": [
+            "^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$",
             {
-                "except": [
-                    "first-nested"
-                ],
-                "ignore": [
-                    "after-comment"
-                ]
-            }
+                message: "Expected variable to be camelCase",
+            },
         ],
-        "shorthand-property-no-redundant-values": true,
-        "scss/dollar-variable-pattern": "^[a-z][a-z-A-Z0-9]*$",
-        "scss/dollar-variable-colon-space-after": "always-single-line",
-        "scss/dollar-variable-colon-space-before": "never",
-        "scss/dollar-variable-empty-line-before": [
-            "always",
+        "scss/percent-placeholder-pattern": [
+            "^[a-z][a-z-A-Z0-9]*$",
             {
-                "except": [
-                    "first-nested",
-                    "after-comment",
-                    "after-dollar-variable"
-                ]
-            }
+                message: "Expected placeholder to be camelCase",
+            },
         ],
-        "scss/percent-placeholder-pattern": "^[a-z][a-z-A-Z0-9]*$",
-        "scss/double-slash-comment-whitespace-inside": "always",
         "scss/declaration-nested-properties": "never",
-        "scss/operator-no-newline-after": true,
-        "scss/operator-no-newline-before": true,
-        "scss/operator-no-unspaced": true,
-        "scss/at-else-if-parentheses-space-before": "always",
-        "scss/at-function-parentheses-space-before": "never",
-        "scss/at-function-pattern": "^[a-z][a-z-A-Z0-9]*$",
-        "scss/at-mixin-parentheses-space-before": "never",
-        "scss/at-else-closing-brace-newline-after": "always-last-in-chain",
-        "scss/at-else-closing-brace-space-after": "always-intermediate",
-        "scss/at-else-empty-line-before": "never",
-        "scss/at-if-closing-brace-newline-after": "always-last-in-chain",
-        "scss/at-if-closing-brace-space-after": "always-intermediate"
+        "scss/at-function-pattern": [
+            "^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$",
+            {
+                message: "Expected function name to be camelCase",
+            },
+        ],
     }
 }

--- a/index.js
+++ b/index.js
@@ -5,20 +5,6 @@ module.exports = {
     'customSyntax': 'postcss-scss',
     'rules': {
         'alpha-value-notation': 'number',
-        'at-rule-empty-line-before': [
-            'always',
-            {
-                except: ['blockless-after-blockless', 'first-nested'],
-                ignore: ['after-comment'],
-                ignoreAtRules: [
-                    'media',
-                    'return',
-                    'extend',
-                    'include',
-                    'else',
-                ]
-            }
-        ],
         'block-no-empty': true,
         'color-hex-length': 'long',
         'comment-no-empty': true,
@@ -40,27 +26,12 @@ module.exports = {
                 message: (selector) => `Expected class selector '${selector}' to match BEM CSS pattern (https://en.bem.info/methodology/css). Selector validation tool: https://regexr.com/3apms`,
             },
         ],
-        'selector-max-compound-selectors': [
-            3,
-            {
-                severity: 'warning'
-            }
-        ],
+        'selector-max-compound-selectors': 3,
         'selector-max-id': 0,
-        'selector-max-type': [
-            2,
-            {
-                severity: 'warning'
-            }
-        ],
-        'selector-max-combinators': [
-            2,
-            {
-                severity: 'warning'
-            }
-        ],
+        'selector-max-type': 2,
+        'selector-max-combinators': 2,
         'selector-max-universal': 1,
-        'selector-max-specificity': '0,3,1',
+        'selector-max-specificity': '0,3,0',
         'value-keyword-case': [
             'lower',
             {
@@ -81,6 +52,7 @@ module.exports = {
             },
         ],
         'scss/declaration-nested-properties': 'never',
+        'scss/double-slash-comment-empty-line-before': null,
         'scss/dollar-variable-pattern': [
             '^[a-z]+((\\d)|([A-Z0-9][a-z0-9]+))*([A-Z])*$',
             {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
     'extends': 'stylelint-config-standard-scss',
     'customSyntax': 'postcss-scss',
     'rules': {
+        'alpha-value-notation': 'number',
         'at-rule-empty-line-before': [
             'always',
             {
@@ -60,7 +61,6 @@ module.exports = {
         ],
         'selector-max-universal': 1,
         'selector-max-specificity': '0,3,1',
-        'selector-not-notation': 'simple',
         'value-keyword-case': [
             'lower',
             {

--- a/package.json
+++ b/package.json
@@ -15,20 +15,19 @@
     "stylelintconfig",
     "massiveart"
   ],
-  "author": "MASSIVE ART Webservices GmbH",
+  "author": "MASSIVE ART WebServices GmbH",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/massiveart/stylelint-config-ma/issues"
   },
   "homepage": "https://github.com/massiveart/stylelint-config-ma#readme",
   "dependencies": {
-    "stylelint-config-standard": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0 || ^25.0.0",
-    "stylelint-scss": "^3.0.0 || ^4.1.0"
+    "stylelint-config-standard-scss": "^7.0.1"
   },
   "devDependencies": {
-    "postcss": "^8.4.7",
-    "postcss-scss": "^4.0.3",
-    "stylelint": "^14.0.0"
+    "postcss": "^8.4.21",
+    "postcss-scss": "^4.0.6",
+    "stylelint": "^15.3.0"
   },
   "peerDependencies": {
     "stylelint": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0"

--- a/test/animation.scss
+++ b/test/animation.scss
@@ -1,4 +1,4 @@
-@keyframes example-test {
+@keyframes exampleTest {
     from {
         background-color: red;
     }
@@ -9,9 +9,9 @@
 }
 
 .test {
-    animation-name: example-test;
+    animation-name: exampleTest;
 }
 
 .unknown {
-    animation-name: unknown-function;
+    animation-name: unknownFunction;
 }

--- a/test/compound-selectors.scss
+++ b/test/compound-selectors.scss
@@ -1,0 +1,3 @@
+.foo .bar .baz {
+    display: block;
+}

--- a/test/content.scss
+++ b/test/content.scss
@@ -1,0 +1,11 @@
+@mixin mq($width) {
+    @media screen and (max-width: $width) {
+        @content;
+    }
+}
+
+.test {
+    @include mq(700px) {
+        color: green;
+    }
+}

--- a/test/empty-line.scss
+++ b/test/empty-line.scss
@@ -1,0 +1,9 @@
+.empty-line {
+    @include shadow();
+    @include other();
+    color: red;
+
+    @media screen and (max-width: 1024px) {
+        color: blue;
+    }
+}

--- a/test/for.scss
+++ b/test/for.scss
@@ -1,7 +1,9 @@
-$grid-columns: 12;
+@use 'sass:math';
 
-@for $i from 1 through $grid-columns {
+$gridColumns: 12;
+
+@for $i from 1 through $gridColumns {
     .width-#{$i} {
-        width: percentage($i / $grid-columns) !important;
+        width: math.percentage($i / $gridColumns) !important;
     }
 }

--- a/test/if-else.scss
+++ b/test/if-else.scss
@@ -3,7 +3,7 @@ $test: 1;
 .test {
     @if $test == 1 {
         color: red;
-    } @elseif $test == 2 {
+    } @else if $test == 2 {
         color: blue;
     } @else {
         color: purple;

--- a/test/selector-max-type.scss
+++ b/test/selector-max-type.scss
@@ -1,0 +1,3 @@
+div a {
+    color: green;
+}


### PR DESCRIPTION
- Extend from [stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) instead of [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard)

- Removed [deprecated rules](https://stylelint.io/migration-guide/to-15/#deprecated-stylistic-rules)

- Use stricter RegEx patterns for the classes (BEM) and variables/functions (camelCase)

- Diffs (created via `npx stylelint --print-config`) between the current `master` branch and this MR can be viewed here (for 7 days): https://www.diffchecker.com/BhBqEkXd/